### PR TITLE
First error free build of dist and dist-osx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 libs/*/build/
 libs/*/dist/
+nomad/osx-dist/
 nomad/nomad-dist/
 nomad/nomad-source/plugins/
 nomad/nomad-source/plugin-tmp/


### PR DESCRIPTION
First error free build of the normal and osx version of Nomad.
Tested to run the application on a Mac book Pro, but without midi hardware so no connecion to NM.